### PR TITLE
Upgrade spark 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+#Jetbrains-IDE
+.idea/

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "spark-streaming-mqtt-raspberryPi"
 val spark = "org.apache.spark" %% "spark-core" % "1.6.2"
 val sparkStreamingMqtt = "org.apache.spark" %% "spark-streaming-mqtt" % "1.6.2"
 val sparkStreaming = "org.apache.spark" %% "spark-streaming" % "1.6.2"
-
+val config = "com.typesafe" % "config" % "1.3.1"
 
 resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
 
@@ -18,7 +18,7 @@ lazy val commonSettings = Seq(
 lazy val root = (project in file(".")).
   settings(commonSettings: _*).
   settings(
-    libraryDependencies ++= Seq(spark, sparkStreaming,sparkStreamingMqtt)
+    libraryDependencies ++= Seq(spark, sparkStreaming,sparkStreamingMqtt, config)
   )
 
 assembleArtifact in assemblyPackageScala := false // We don't need the Scala library, Spark already includes it

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+mosquitto-server {
+  url = localhost
+  port = 1883
+}

--- a/src/main/scala/MQTTPublisher.scala
+++ b/src/main/scala/MQTTPublisher.scala
@@ -15,9 +15,10 @@ import scala.util.Try
   */
 
 object MQTTPublisher extends App {
+  lazy val config= ConfigFactory.load()
 
-  val url = Try(ConfigFactory.load().getString("mosquitto-server.url")).toOption.fold("localhost")
-  val port = Try(ConfigFactory.load().getInt("mosquitto-server.port")).toOption.fold(1883)
+  val url = Try(config.getString("mosquitto-server.url")).getOrElse("localhost")
+  val port = Try(config.getInt("mosquitto-server.port")).getOrElse(1883)
 
   def publishToserver() = {
     println("Hey I am publishing")


### PR DESCRIPTION
This patch upgrades to spark 2.0.0 #4 . Also fixes #6 

For spark-streaming-mqtt package I used org.apache.bahir. Seems like since spark version 2.0 park-streaming-mqtt becomes a separate project.
[http://bahir.apache.org/docs/spark/2.0.0/spark-sql-streaming-mqtt/](url)
